### PR TITLE
Make HDR color optional

### DIFF
--- a/Editor/SDFUIEditor.cs
+++ b/Editor/SDFUIEditor.cs
@@ -391,8 +391,7 @@ namespace TLab.UI.SDF.Editor
 		{
 			EditorGUILayout.LabelField("Others", labelStyle);
 			EditorGUI.indentLevel++;
-			var color = EditorGUILayout.ColorField(new GUIContent("Color"), m_Color.colorValue, false, true, true);
-			m_Color.colorValue = color;
+			EditorGUILayout.PropertyField(m_Color);
 			RaycastControlsGUI();
 			MaskableControlsGUI();
 			SetShowNativeSize(false);

--- a/Editor/SDFUIEditor.cs
+++ b/Editor/SDFUIEditor.cs
@@ -130,14 +130,14 @@ namespace TLab.UI.SDF.Editor
 					}
 					break;
 			}
-			serializedObject.TryDrawColorProperty("m_" + nameof(m_baseInstance.fillColor), "FillColor");
+			serializedObject.TryDrawColorProperty("m_" + nameof(m_baseInstance.fillColor), "FillColor", m_baseInstance.useHDR);
 
 			serializedObject.TryDrawProperty("m_" + nameof(m_baseInstance.gradationShape), "Gradation Shape");
 			EditorGUI.indentLevel++;
 			bool drawGradationColor = m_baseInstance.gradationShape != SDFUI.GradationShape.None;
 			if (drawGradationColor)
 			{
-				serializedObject.TryDrawColorProperty("m_" + nameof(m_baseInstance.gradationColor), "Color");
+				serializedObject.TryDrawColorProperty("m_" + nameof(m_baseInstance.gradationColor), "Color", m_baseInstance.useHDR);
 				switch (m_baseInstance.gradationShape)
 				{
 					case SDFUI.GradationShape.Linear:
@@ -165,14 +165,14 @@ namespace TLab.UI.SDF.Editor
 				case SDFUI.EffectType.None:
 					break;
 				case SDFUI.EffectType.Shiny:
-					serializedObject.TryDrawColorProperty("m_" + nameof(m_baseInstance.graphicEffectColor), "Color");
+					serializedObject.TryDrawColorProperty("m_" + nameof(m_baseInstance.graphicEffectColor), "Color", m_baseInstance.useHDR);
 					serializedObject.TryDrawProperty("m_" + nameof(m_baseInstance.graphicEffectAngle), "Angle");
 					serializedObject.TryDrawProperty("m_" + nameof(m_baseInstance.graphicEffectShinyWidth), "Width");
 					serializedObject.TryDrawProperty("m_" + nameof(m_baseInstance.graphicEffectShinyBlur), "Blur");
 					serializedObject.TryDrawProperty("m_" + nameof(m_baseInstance.graphicEffectOffset), "Offset");
 					break;
 				case SDFUI.EffectType.Pattern:
-					serializedObject.TryDrawColorProperty("m_" + nameof(m_baseInstance.graphicEffectColor), "Color");
+					serializedObject.TryDrawColorProperty("m_" + nameof(m_baseInstance.graphicEffectColor), "Color", m_baseInstance.useHDR);
 					serializedObject.TryDrawProperty("m_" + nameof(m_baseInstance.graphicEffectAngle), "Angle");
 
 					serializedObject.TryDrawProperty("m_" + nameof(m_baseInstance.graphicEffectPatternTexture), "Texture");
@@ -223,14 +223,14 @@ namespace TLab.UI.SDF.Editor
 			if (m_baseInstance.outline)
 			{
 				serializedObject.TryDrawProperty("m_" + nameof(m_baseInstance.outlineWidth), "Width");
-				serializedObject.TryDrawColorProperty("m_" + nameof(m_baseInstance.outlineColor), "Color");
+				serializedObject.TryDrawColorProperty("m_" + nameof(m_baseInstance.outlineColor), "Color", m_baseInstance.useHDR);
 
 				serializedObject.TryDrawProperty("m_" + nameof(m_baseInstance.outlineGradationShape), "Gradation Shape");
 				EditorGUI.indentLevel++;
 				bool drawGradationColor = m_baseInstance.outlineGradationShape != SDFUI.GradationShape.None;
 				if (drawGradationColor)
 				{
-					serializedObject.TryDrawColorProperty("m_" + nameof(m_baseInstance.outlineGradationColor), "Color");
+					serializedObject.TryDrawColorProperty("m_" + nameof(m_baseInstance.outlineGradationColor), "Color", m_baseInstance.useHDR);
 					switch (m_baseInstance.outlineGradationShape)
 					{
 						case SDFUI.GradationShape.Linear:
@@ -263,14 +263,14 @@ namespace TLab.UI.SDF.Editor
 					case SDFUI.EffectType.None:
 						break;
 					case SDFUI.EffectType.Shiny:
-						serializedObject.TryDrawColorProperty("m_" + nameof(m_baseInstance.outlineEffectColor), "Color");
+						serializedObject.TryDrawColorProperty("m_" + nameof(m_baseInstance.outlineEffectColor), "Color", m_baseInstance.useHDR);
 						serializedObject.TryDrawProperty("m_" + nameof(m_baseInstance.outlineEffectAngle), "Angle");
 						serializedObject.TryDrawProperty("m_" + nameof(m_baseInstance.outlineEffectShinyWidth), "Width");
 						serializedObject.TryDrawProperty("m_" + nameof(m_baseInstance.outlineEffectShinyBlur), "Blur");
 						serializedObject.TryDrawProperty("m_" + nameof(m_baseInstance.outlineEffectOffset), "Offset");
 						break;
 					case SDFUI.EffectType.Pattern:
-						serializedObject.TryDrawColorProperty("m_" + nameof(m_baseInstance.outlineEffectColor), "Color");
+						serializedObject.TryDrawColorProperty("m_" + nameof(m_baseInstance.outlineEffectColor), "Color", m_baseInstance.useHDR);
 						serializedObject.TryDrawProperty("m_" + nameof(m_baseInstance.outlineEffectAngle), "Angle");
 
 						serializedObject.TryDrawProperty("m_" + nameof(m_baseInstance.outlineEffectPatternTexture), "Texture");
@@ -327,14 +327,14 @@ namespace TLab.UI.SDF.Editor
 			EditorGUI.indentLevel++;
 			if (m_baseInstance.shadow)
 			{
-				serializedObject.TryDrawColorProperty("m_" + nameof(m_baseInstance.shadowColor), "Color");
+				serializedObject.TryDrawColorProperty("m_" + nameof(m_baseInstance.shadowColor), "Color", m_baseInstance.useHDR);
 
 				serializedObject.TryDrawProperty("m_" + nameof(m_baseInstance.shadowGradationShape), "Gradation Shape");
 				EditorGUI.indentLevel++;
 				bool drawGradationColor = m_baseInstance.shadowGradationShape != SDFUI.GradationShape.None;
 				if (drawGradationColor)
 				{
-					serializedObject.TryDrawColorProperty("m_" + nameof(m_baseInstance.shadowGradationColor), "Color");
+					serializedObject.TryDrawColorProperty("m_" + nameof(m_baseInstance.shadowGradationColor), "Color", m_baseInstance.useHDR);
 					switch (m_baseInstance.shadowGradationShape)
 					{
 						case SDFUI.GradationShape.Linear:
@@ -387,6 +387,11 @@ namespace TLab.UI.SDF.Editor
 			serializedObject.TryDrawProperty("m_" + nameof(m_baseInstance.antialiasing), "Antialiasing");
 		}
 
+		protected void DrawUseHDRProp()
+		{
+			serializedObject.TryDrawProperty("m_" + nameof(m_baseInstance.useHDR), "Use HDR");
+		}
+
 		protected virtual void DrawOtherProp()
 		{
 			EditorGUILayout.LabelField("Others", labelStyle);
@@ -397,6 +402,7 @@ namespace TLab.UI.SDF.Editor
 			SetShowNativeSize(false);
 			NativeSizeButtonGUI();
 			DrawAntialiasingProp();
+			DrawUseHDRProp();
 			EditorGUI.indentLevel--;
 		}
 

--- a/Editor/SDFUIEditor.cs
+++ b/Editor/SDFUIEditor.cs
@@ -130,14 +130,14 @@ namespace TLab.UI.SDF.Editor
 					}
 					break;
 			}
-			serializedObject.TryDrawProperty("m_" + nameof(m_baseInstance.fillColor), "FillColor");
+			serializedObject.TryDrawColorProperty("m_" + nameof(m_baseInstance.fillColor), "FillColor");
 
 			serializedObject.TryDrawProperty("m_" + nameof(m_baseInstance.gradationShape), "Gradation Shape");
 			EditorGUI.indentLevel++;
 			bool drawGradationColor = m_baseInstance.gradationShape != SDFUI.GradationShape.None;
 			if (drawGradationColor)
 			{
-				serializedObject.TryDrawProperty("m_" + nameof(m_baseInstance.gradationColor), "Color");
+				serializedObject.TryDrawColorProperty("m_" + nameof(m_baseInstance.gradationColor), "Color");
 				switch (m_baseInstance.gradationShape)
 				{
 					case SDFUI.GradationShape.Linear:
@@ -165,14 +165,14 @@ namespace TLab.UI.SDF.Editor
 				case SDFUI.EffectType.None:
 					break;
 				case SDFUI.EffectType.Shiny:
-					serializedObject.TryDrawProperty("m_" + nameof(m_baseInstance.graphicEffectColor), "Color");
+					serializedObject.TryDrawColorProperty("m_" + nameof(m_baseInstance.graphicEffectColor), "Color");
 					serializedObject.TryDrawProperty("m_" + nameof(m_baseInstance.graphicEffectAngle), "Angle");
 					serializedObject.TryDrawProperty("m_" + nameof(m_baseInstance.graphicEffectShinyWidth), "Width");
 					serializedObject.TryDrawProperty("m_" + nameof(m_baseInstance.graphicEffectShinyBlur), "Blur");
 					serializedObject.TryDrawProperty("m_" + nameof(m_baseInstance.graphicEffectOffset), "Offset");
 					break;
 				case SDFUI.EffectType.Pattern:
-					serializedObject.TryDrawProperty("m_" + nameof(m_baseInstance.graphicEffectColor), "Color");
+					serializedObject.TryDrawColorProperty("m_" + nameof(m_baseInstance.graphicEffectColor), "Color");
 					serializedObject.TryDrawProperty("m_" + nameof(m_baseInstance.graphicEffectAngle), "Angle");
 
 					serializedObject.TryDrawProperty("m_" + nameof(m_baseInstance.graphicEffectPatternTexture), "Texture");
@@ -223,14 +223,14 @@ namespace TLab.UI.SDF.Editor
 			if (m_baseInstance.outline)
 			{
 				serializedObject.TryDrawProperty("m_" + nameof(m_baseInstance.outlineWidth), "Width");
-				serializedObject.TryDrawProperty("m_" + nameof(m_baseInstance.outlineColor), "Color");
+				serializedObject.TryDrawColorProperty("m_" + nameof(m_baseInstance.outlineColor), "Color");
 
 				serializedObject.TryDrawProperty("m_" + nameof(m_baseInstance.outlineGradationShape), "Gradation Shape");
 				EditorGUI.indentLevel++;
 				bool drawGradationColor = m_baseInstance.outlineGradationShape != SDFUI.GradationShape.None;
 				if (drawGradationColor)
 				{
-					serializedObject.TryDrawProperty("m_" + nameof(m_baseInstance.outlineGradationColor), "Color");
+					serializedObject.TryDrawColorProperty("m_" + nameof(m_baseInstance.outlineGradationColor), "Color");
 					switch (m_baseInstance.outlineGradationShape)
 					{
 						case SDFUI.GradationShape.Linear:
@@ -263,14 +263,14 @@ namespace TLab.UI.SDF.Editor
 					case SDFUI.EffectType.None:
 						break;
 					case SDFUI.EffectType.Shiny:
-						serializedObject.TryDrawProperty("m_" + nameof(m_baseInstance.outlineEffectColor), "Color");
+						serializedObject.TryDrawColorProperty("m_" + nameof(m_baseInstance.outlineEffectColor), "Color");
 						serializedObject.TryDrawProperty("m_" + nameof(m_baseInstance.outlineEffectAngle), "Angle");
 						serializedObject.TryDrawProperty("m_" + nameof(m_baseInstance.outlineEffectShinyWidth), "Width");
 						serializedObject.TryDrawProperty("m_" + nameof(m_baseInstance.outlineEffectShinyBlur), "Blur");
 						serializedObject.TryDrawProperty("m_" + nameof(m_baseInstance.outlineEffectOffset), "Offset");
 						break;
 					case SDFUI.EffectType.Pattern:
-						serializedObject.TryDrawProperty("m_" + nameof(m_baseInstance.outlineEffectColor), "Color");
+						serializedObject.TryDrawColorProperty("m_" + nameof(m_baseInstance.outlineEffectColor), "Color");
 						serializedObject.TryDrawProperty("m_" + nameof(m_baseInstance.outlineEffectAngle), "Angle");
 
 						serializedObject.TryDrawProperty("m_" + nameof(m_baseInstance.outlineEffectPatternTexture), "Texture");
@@ -327,14 +327,14 @@ namespace TLab.UI.SDF.Editor
 			EditorGUI.indentLevel++;
 			if (m_baseInstance.shadow)
 			{
-				serializedObject.TryDrawProperty("m_" + nameof(m_baseInstance.shadowColor), "Color");
+				serializedObject.TryDrawColorProperty("m_" + nameof(m_baseInstance.shadowColor), "Color");
 
 				serializedObject.TryDrawProperty("m_" + nameof(m_baseInstance.shadowGradationShape), "Gradation Shape");
 				EditorGUI.indentLevel++;
 				bool drawGradationColor = m_baseInstance.shadowGradationShape != SDFUI.GradationShape.None;
 				if (drawGradationColor)
 				{
-					serializedObject.TryDrawProperty("m_" + nameof(m_baseInstance.shadowGradationColor), "Color");
+					serializedObject.TryDrawColorProperty("m_" + nameof(m_baseInstance.shadowGradationColor), "Color");
 					switch (m_baseInstance.shadowGradationShape)
 					{
 						case SDFUI.GradationShape.Linear:

--- a/Editor/Settings Editor/SDFUISettingsEditor.uxml
+++ b/Editor/Settings Editor/SDFUISettingsEditor.uxml
@@ -27,6 +27,9 @@
                 <uie:ColorField label="Color" value="#00000040" name="shadow-color" binding-path="_shadowColor" />
                 <uie:Vector2Field label="Offset" binding-path="_shadowOffset" />
             </ui:Foldout>
+            <ui:Foldout text="HDR" name="hdr">
+                <ui:Toggle label="Enable" name="hdr-enable" binding-path="_useHDRColor" />
+            </ui:Foldout>
         </ui:GroupBox>
     </ui:ScrollView>
 </ui:UXML>

--- a/Editor/Settings Editor/SDFUISettingsEditor.uxml
+++ b/Editor/Settings Editor/SDFUISettingsEditor.uxml
@@ -28,7 +28,7 @@
                 <uie:Vector2Field label="Offset" binding-path="_shadowOffset" />
             </ui:Foldout>
             <ui:Foldout text="HDR" name="hdr">
-                <ui:Toggle label="Enable" name="hdr-enable" binding-path="_useHDRColor" />
+                <ui:Toggle label="Enable" name="hdr-enable" binding-path="_useHDR" />
             </ui:Foldout>
         </ui:GroupBox>
     </ui:ScrollView>

--- a/Editor/Util/SerializeUtil.cs
+++ b/Editor/Util/SerializeUtil.cs
@@ -217,13 +217,13 @@ namespace TLab.UI.SDF.Editor
 			return false;
 		}
 
-		public static bool TryDrawColorProperty(this SerializedObject serializedObject, string name, string label)
+		public static bool TryDrawColorProperty(this SerializedObject serializedObject, string name, string label, bool hdr)
 		{
 			var prop = serializedObject.FindProperty(name);
 			if (prop != null)
 			{
 				var color = prop.colorValue;
-				color = EditorGUILayout.ColorField(new GUIContent(label), color, true, true, SDFUISettings.Instance.UseHDRColor);
+				color = EditorGUILayout.ColorField(new GUIContent(label), color, true, true, hdr);
 				prop.colorValue = color;
 				return true;
 			}

--- a/Editor/Util/SerializeUtil.cs
+++ b/Editor/Util/SerializeUtil.cs
@@ -217,6 +217,19 @@ namespace TLab.UI.SDF.Editor
 			return false;
 		}
 
+		public static bool TryDrawColorProperty(this SerializedObject serializedObject, string name, string label)
+		{
+			var prop = serializedObject.FindProperty(name);
+			if (prop != null)
+			{
+				var color = prop.colorValue;
+				color = EditorGUILayout.ColorField(new GUIContent(label), color, true, true, SDFUISettings.Instance.UseHDRColor);
+				prop.colorValue = color;
+				return true;
+			}
+			return false;
+		}
+
 		public static void Call(this SerializedObject serializedObject, UnityAction action)
 		{
 			serializedObject.ApplyModifiedProperties();

--- a/Runtime/Registry/MaterialRegistry.cs
+++ b/Runtime/Registry/MaterialRegistry.cs
@@ -13,7 +13,7 @@ namespace TLab.UI.SDF.Registry
 		static MaterialRegistry()
 		{
 #if UNITY_EDITOR
-			SDFUISettings.AASettingsChanged += OnSettingsChanged;
+			SDFUISettings.SettingsChanged += OnSettingsChanged;
 #endif
 		}
 

--- a/Runtime/Registry/MaterialRegistry.cs
+++ b/Runtime/Registry/MaterialRegistry.cs
@@ -13,7 +13,7 @@ namespace TLab.UI.SDF.Registry
 		static MaterialRegistry()
 		{
 #if UNITY_EDITOR
-			SDFUISettings.SettingsChanged += OnSettingsChanged;
+			SDFUISettings.AASettingsChanged += OnSettingsChanged;
 #endif
 		}
 

--- a/Runtime/Resources/Shaders/SDF-UI/ApproxSquircle.shader
+++ b/Runtime/Resources/Shaders/SDF-UI/ApproxSquircle.shader
@@ -1,6 +1,7 @@
 Shader "Hidden/UI/SDF/ApproxSquircle/Outline" {
     Properties{
         [HideInInspector] _MainTex("Texture", 2D) = "white" {}
+        [HideInInspector] _Color("Tint", Color) = (1,1,1,1)
         [HideInInspector] _StencilComp("Stencil Comparison", Float) = 8
         [HideInInspector] _Stencil("Stencil ID", Float) = 0
         [HideInInspector] _StencilOp("Stencil Operation", Float) = 0
@@ -41,8 +42,8 @@ Shader "Hidden/UI/SDF/ApproxSquircle/Outline" {
         _OutlineGradationRange("Outline Gradation Range", Vector) = (0.0, 0.0, 0.0, 1.0)
         _OutlineGradationLayer("Outline Gradation Layer", Vector) = (0.0, 0.0, 0.0, 1.0)
         _OutlineGradationOffset("Outline Gradation Offset", Vector) = (0.0, 0.0, 0.0, 1.0)
-        [HDR] _OutlineColor("Outline Color", Color) = (0.0, 0.0, 0.0, 1.0)
-        [HDR] _OutlineGradationColor("Outline Gradation Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _OutlineColor("Outline Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _OutlineGradationColor("Outline Gradation Color", Color) = (0.0, 0.0, 0.0, 1.0)
 
         _ShadowWidth("Shadow Width", Float) = 0
         _ShadowBlur("Shadow Blur", Float) = 0
@@ -54,14 +55,14 @@ Shader "Hidden/UI/SDF/ApproxSquircle/Outline" {
         _ShadowGradationRange("Shadow Gradation Range", Vector) = (0.0, 0.0, 0.0, 1.0)
         _ShadowGradationLayer("Shadow Gradation Layer", Vector) = (0.0, 0.0, 0.0, 1.0)
         _ShadowGradationOffset("Shadow Gradation Offset", Vector) = (0.0, 0.0, 0.0, 1.0)
-        [HDR] _ShadowColor("Shadow Color", Color) = (0.0, 0.0, 0.0, 1.0)
-        [HDR] _ShadowGradationColor("Shadow Gradation Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _ShadowColor("Shadow Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _ShadowGradationColor("Shadow Gradation Color", Color) = (0.0, 0.0, 0.0, 1.0)
 
         _GraphicEffectAngle("Graphic Effect Angle", Float) = 0
-        [HDR] _GraphicEffectColor("Graphic Effect Color", Vector) = (0.0, 0.0, 0.0, 1.0)
+        _GraphicEffectColor("Graphic Effect Color", Color) = (0.0, 0.0, 0.0, 1.0)
         _GraphicEffectOffset("Graphic Effect Offset", Vector) = (0.0, 0.0, 0.0, 1.0)
         _OutlineEffectAngle("Outline Effect Angle", Float) = 0
-        [HDR] _OutlineEffectColor("Outline Effect Color", Vector) = (0.0, 0.0, 0.0, 1.0)
+        _OutlineEffectColor("Outline Effect Color", Color) = (0.0, 0.0, 0.0, 1.0)
         _OutlineEffectOffset("Outline Effect Offset", Vector) = (0.0, 0.0, 0.0, 1.0)
 
         _GraphicEffectShinyWidth("Graphic Effect Shiny Width", Float) = 0

--- a/Runtime/Resources/Shaders/SDF-UI/Arc.shader
+++ b/Runtime/Resources/Shaders/SDF-UI/Arc.shader
@@ -1,6 +1,7 @@
 Shader "Hidden/UI/SDF/Arc/Outline" {
     Properties{
         [HideInInspector] _MainTex("Texture", 2D) = "white" {}
+        [HideInInspector] _Color("Tint", Color) = (1,1,1,1)
         [HideInInspector] _StencilComp("Stencil Comparison", Float) = 8
         [HideInInspector] _Stencil("Stencil ID", Float) = 0
         [HideInInspector] _StencilOp("Stencil Operation", Float) = 0
@@ -44,8 +45,8 @@ Shader "Hidden/UI/SDF/Arc/Outline" {
         _OutlineGradationRange("Outline Gradation Range", Vector) = (0.0, 0.0, 0.0, 1.0)
         _OutlineGradationLayer("Outline Gradation Layer", Vector) = (0.0, 0.0, 0.0, 1.0)
         _OutlineGradationOffset("Outline Gradation Offset", Vector) = (0.0, 0.0, 0.0, 1.0)
-        [HDR] _OutlineColor("Outline Color", Color) = (0.0, 0.0, 0.0, 1.0)
-        [HDR] _OutlineGradationColor("Outline Gradation Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _OutlineColor("Outline Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _OutlineGradationColor("Outline Gradation Color", Color) = (0.0, 0.0, 0.0, 1.0)
 
         _ShadowWidth("Shadow Width", Float) = 0
         _ShadowBlur("Shadow Blur", Float) = 0
@@ -57,14 +58,14 @@ Shader "Hidden/UI/SDF/Arc/Outline" {
         _ShadowGradationRange("Shadow Gradation Range", Vector) = (0.0, 0.0, 0.0, 1.0)
         _ShadowGradationLayer("Shadow Gradation Layer", Vector) = (0.0, 0.0, 0.0, 1.0)
         _ShadowGradationOffset("Shadow Gradation Offset", Vector) = (0.0, 0.0, 0.0, 1.0)
-        [HDR] _ShadowColor("Shadow Color", Color) = (0.0, 0.0, 0.0, 1.0)
-        [HDR] _ShadowGradationColor("Shadow Gradation Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _ShadowColor("Shadow Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _ShadowGradationColor("Shadow Gradation Color", Color) = (0.0, 0.0, 0.0, 1.0)
 
         _GraphicEffectAngle("Graphic Effect Angle", Float) = 0
-        [HDR] _GraphicEffectColor("Graphic Effect Color", Vector) = (0.0, 0.0, 0.0, 1.0)
+        _GraphicEffectColor("Graphic Effect Color", Color) = (0.0, 0.0, 0.0, 1.0)
         _GraphicEffectOffset("Graphic Effect Offset", Vector) = (0.0, 0.0, 0.0, 1.0)
         _OutlineEffectAngle("Outline Effect Angle", Float) = 0
-        [HDR] _OutlineEffectColor("Outline Effect Color", Vector) = (0.0, 0.0, 0.0, 1.0)
+        _OutlineEffectColor("Outline Effect Color", Color) = (0.0, 0.0, 0.0, 1.0)
         _OutlineEffectOffset("Outline Effect Offset", Vector) = (0.0, 0.0, 0.0, 1.0)
 
         _GraphicEffectShinyWidth("Graphic Effect Shiny Width", Float) = 0

--- a/Runtime/Resources/Shaders/SDF-UI/Circle.shader
+++ b/Runtime/Resources/Shaders/SDF-UI/Circle.shader
@@ -1,6 +1,7 @@
 Shader "Hidden/UI/SDF/Circle/Outline" {
     Properties{
         [HideInInspector] _MainTex("Texture", 2D) = "white" {}
+        [HideInInspector] _Color("Tint", Color) = (1,1,1,1)
         [HideInInspector] _StencilComp("Stencil Comparison", Float) = 8
         [HideInInspector] _Stencil("Stencil ID", Float) = 0
         [HideInInspector] _StencilOp("Stencil Operation", Float) = 0
@@ -39,8 +40,8 @@ Shader "Hidden/UI/SDF/Circle/Outline" {
         _OutlineGradationRange("Outline Gradation Range", Vector) = (0.0, 0.0, 0.0, 1.0)
         _OutlineGradationLayer("Outline Gradation Layer", Vector) = (0.0, 0.0, 0.0, 1.0)
         _OutlineGradationOffset("Outline Gradation Offset", Vector) = (0.0, 0.0, 0.0, 1.0)
-        [HDR] _OutlineColor("Outline Color", Color) = (0.0, 0.0, 0.0, 1.0)
-        [HDR] _OutlineGradationColor("Outline Gradation Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _OutlineColor("Outline Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _OutlineGradationColor("Outline Gradation Color", Color) = (0.0, 0.0, 0.0, 1.0)
 
         _ShadowWidth("Shadow Width", Float) = 0
         _ShadowBlur("Shadow Blur", Float) = 0
@@ -52,14 +53,14 @@ Shader "Hidden/UI/SDF/Circle/Outline" {
         _ShadowGradationRange("Shadow Gradation Range", Vector) = (0.0, 0.0, 0.0, 1.0)
         _ShadowGradationLayer("Shadow Gradation Layer", Vector) = (0.0, 0.0, 0.0, 1.0)
         _ShadowGradationOffset("Shadow Gradation Offset", Vector) = (0.0, 0.0, 0.0, 1.0)
-        [HDR] _ShadowColor("Shadow Color", Color) = (0.0, 0.0, 0.0, 1.0)
-        [HDR] _ShadowGradationColor("Shadow Gradation Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _ShadowColor("Shadow Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _ShadowGradationColor("Shadow Gradation Color", Color) = (0.0, 0.0, 0.0, 1.0)
 
         _GraphicEffectAngle("Graphic Effect Angle", Float) = 0
-        [HDR] _GraphicEffectColor("Graphic Effect Color", Vector) = (0.0, 0.0, 0.0, 1.0)
+        _GraphicEffectColor("Graphic Effect Color", Color) = (0.0, 0.0, 0.0, 1.0)
         _GraphicEffectOffset("Graphic Effect Offset", Vector) = (0.0, 0.0, 0.0, 1.0)
         _OutlineEffectAngle("Outline Effect Angle", Float) = 0
-        [HDR] _OutlineEffectColor("Outline Effect Color", Vector) = (0.0, 0.0, 0.0, 1.0)
+        _OutlineEffectColor("Outline Effect Color", Color) = (0.0, 0.0, 0.0, 1.0)
         _OutlineEffectOffset("Outline Effect Offset", Vector) = (0.0, 0.0, 0.0, 1.0)
 
         _GraphicEffectShinyWidth("Graphic Effect Shiny Width", Float) = 0

--- a/Runtime/Resources/Shaders/SDF-UI/Common-Properties.hlsl
+++ b/Runtime/Resources/Shaders/SDF-UI/Common-Properties.hlsl
@@ -88,6 +88,7 @@ float4 _ShadowGradationOffset;
 float4 _ClipRect;
 float _UIMaskSoftnessX;
 float _UIMaskSoftnessY;
+int _UIVertexColorAlwaysGammaSpace;
 
 sampler2D _MainTex;
 float4 _MainTex_ST;

--- a/Runtime/Resources/Shaders/SDF-UI/CutDisk.shader
+++ b/Runtime/Resources/Shaders/SDF-UI/CutDisk.shader
@@ -1,6 +1,7 @@
 Shader "Hidden/UI/SDF/CutDisk/Outline" {
     Properties{
         [HideInInspector] _MainTex("Texture", 2D) = "white" {}
+        [HideInInspector] _Color("Tint", Color) = (1,1,1,1)
         [HideInInspector] _StencilComp("Stencil Comparison", Float) = 8
         [HideInInspector] _Stencil("Stencil ID", Float) = 0
         [HideInInspector] _StencilOp("Stencil Operation", Float) = 0
@@ -40,8 +41,8 @@ Shader "Hidden/UI/SDF/CutDisk/Outline" {
         _OutlineGradationRange("Outline Gradation Range", Vector) = (0.0, 0.0, 0.0, 1.0)
         _OutlineGradationLayer("Outline Gradation Layer", Vector) = (0.0, 0.0, 0.0, 1.0)
         _OutlineGradationOffset("Outline Gradation Offset", Vector) = (0.0, 0.0, 0.0, 1.0)
-        [HDR] _OutlineColor("Outline Color", Color) = (0.0, 0.0, 0.0, 1.0)
-        [HDR] _OutlineGradationColor("Outline Gradation Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _OutlineColor("Outline Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _OutlineGradationColor("Outline Gradation Color", Color) = (0.0, 0.0, 0.0, 1.0)
 
         _ShadowWidth("Shadow Width", Float) = 0
         _ShadowBlur("Shadow Blur", Float) = 0
@@ -53,14 +54,14 @@ Shader "Hidden/UI/SDF/CutDisk/Outline" {
         _ShadowGradationRange("Shadow Gradation Range", Vector) = (0.0, 0.0, 0.0, 1.0)
         _ShadowGradationLayer("Shadow Gradation Layer", Vector) = (0.0, 0.0, 0.0, 1.0)
         _ShadowGradationOffset("Shadow Gradation Offset", Vector) = (0.0, 0.0, 0.0, 1.0)
-        [HDR] _ShadowColor("Shadow Color", Color) = (0.0, 0.0, 0.0, 1.0)
-        [HDR] _ShadowGradationColor("Shadow Gradation Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _ShadowColor("Shadow Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _ShadowGradationColor("Shadow Gradation Color", Color) = (0.0, 0.0, 0.0, 1.0)
 
         _GraphicEffectAngle("Graphic Effect Angle", Float) = 0
-        [HDR] _GraphicEffectColor("Graphic Effect Color", Vector) = (0.0, 0.0, 0.0, 1.0)
+        _GraphicEffectColor("Graphic Effect Color", Color) = (0.0, 0.0, 0.0, 1.0)
         _GraphicEffectOffset("Graphic Effect Offset", Vector) = (0.0, 0.0, 0.0, 1.0)
         _OutlineEffectAngle("Outline Effect Angle", Float) = 0
-        [HDR] _OutlineEffectColor("Outline Effect Color", Vector) = (0.0, 0.0, 0.0, 1.0)
+        _OutlineEffectColor("Outline Effect Color", Color) = (0.0, 0.0, 0.0, 1.0)
         _OutlineEffectOffset("Outline Effect Offset", Vector) = (0.0, 0.0, 0.0, 1.0)
 
         _GraphicEffectShinyWidth("Graphic Effect Shiny Width", Float) = 0

--- a/Runtime/Resources/Shaders/SDF-UI/Parallelogram.shader
+++ b/Runtime/Resources/Shaders/SDF-UI/Parallelogram.shader
@@ -1,6 +1,7 @@
 Shader "Hidden/UI/SDF/Parallelogram/Outline" {
     Properties{
         [HideInInspector] _MainTex("Texture", 2D) = "white" {}
+        [HideInInspector] _Color("Tint", Color) = (1,1,1,1)
         [HideInInspector] _StencilComp("Stencil Comparison", Float) = 8
         [HideInInspector] _Stencil("Stencil ID", Float) = 0
         [HideInInspector] _StencilOp("Stencil Operation", Float) = 0
@@ -40,8 +41,8 @@ Shader "Hidden/UI/SDF/Parallelogram/Outline" {
         _OutlineGradationRange("Outline Gradation Range", Vector) = (0.0, 0.0, 0.0, 1.0)
         _OutlineGradationLayer("Outline Gradation Layer", Vector) = (0.0, 0.0, 0.0, 1.0)
         _OutlineGradationOffset("Outline Gradation Offset", Vector) = (0.0, 0.0, 0.0, 1.0)
-        [HDR] _OutlineColor("Outline Color", Color) = (0.0, 0.0, 0.0, 1.0)
-        [HDR] _OutlineGradationColor("Outline Gradation Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _OutlineColor("Outline Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _OutlineGradationColor("Outline Gradation Color", Color) = (0.0, 0.0, 0.0, 1.0)
 
         _ShadowWidth("Shadow Width", Float) = 0
         _ShadowBlur("Shadow Blur", Float) = 0
@@ -53,14 +54,14 @@ Shader "Hidden/UI/SDF/Parallelogram/Outline" {
         _ShadowGradationRange("Shadow Gradation Range", Vector) = (0.0, 0.0, 0.0, 1.0)
         _ShadowGradationLayer("Shadow Gradation Layer", Vector) = (0.0, 0.0, 0.0, 1.0)
         _ShadowGradationOffset("Shadow Gradation Offset", Vector) = (0.0, 0.0, 0.0, 1.0)
-        [HDR] _ShadowColor("Shadow Color", Color) = (0.0, 0.0, 0.0, 1.0)
-        [HDR] _ShadowGradationColor("Shadow Gradation Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _ShadowColor("Shadow Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _ShadowGradationColor("Shadow Gradation Color", Color) = (0.0, 0.0, 0.0, 1.0)
 
         _GraphicEffectAngle("Graphic Effect Angle", Float) = 0
-        [HDR] _GraphicEffectColor("Graphic Effect Color", Vector) = (0.0, 0.0, 0.0, 1.0)
+        _GraphicEffectColor("Graphic Effect Color", Color) = (0.0, 0.0, 0.0, 1.0)
         _GraphicEffectOffset("Graphic Effect Offset", Vector) = (0.0, 0.0, 0.0, 1.0)
         _OutlineEffectAngle("Outline Effect Angle", Float) = 0
-        [HDR] _OutlineEffectColor("Outline Effect Color", Vector) = (0.0, 0.0, 0.0, 1.0)
+        _OutlineEffectColor("Outline Effect Color", Color) = (0.0, 0.0, 0.0, 1.0)
         _OutlineEffectOffset("Outline Effect Offset", Vector) = (0.0, 0.0, 0.0, 1.0)
 
         _GraphicEffectShinyWidth("Graphic Effect Shiny Width", Float) = 0

--- a/Runtime/Resources/Shaders/SDF-UI/Pie.shader
+++ b/Runtime/Resources/Shaders/SDF-UI/Pie.shader
@@ -1,6 +1,7 @@
 Shader "Hidden/UI/SDF/Pie/Outline" {
     Properties{
         [HideInInspector] _MainTex("Texture", 2D) = "white" {}
+        [HideInInspector] _Color("Tint", Color) = (1,1,1,1)
         [HideInInspector] _StencilComp("Stencil Comparison", Float) = 8
         [HideInInspector] _Stencil("Stencil ID", Float) = 0
         [HideInInspector] _StencilOp("Stencil Operation", Float) = 0
@@ -41,8 +42,8 @@ Shader "Hidden/UI/SDF/Pie/Outline" {
         _OutlineGradationRange("Outline Gradation Range", Vector) = (0.0, 0.0, 0.0, 1.0)
         _OutlineGradationLayer("Outline Gradation Layer", Vector) = (0.0, 0.0, 0.0, 1.0)
         _OutlineGradationOffset("Outline Gradation Offset", Vector) = (0.0, 0.0, 0.0, 1.0)
-        [HDR] _OutlineColor("Outline Color", Color) = (0.0, 0.0, 0.0, 1.0)
-        [HDR] _OutlineGradationColor("Outline Gradation Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _OutlineColor("Outline Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _OutlineGradationColor("Outline Gradation Color", Color) = (0.0, 0.0, 0.0, 1.0)
 
         _ShadowWidth("Shadow Width", Float) = 0
         _ShadowBlur("Shadow Blur", Float) = 0
@@ -54,14 +55,14 @@ Shader "Hidden/UI/SDF/Pie/Outline" {
         _ShadowGradationRange("Shadow Gradation Range", Vector) = (0.0, 0.0, 0.0, 1.0)
         _ShadowGradationLayer("Shadow Gradation Layer", Vector) = (0.0, 0.0, 0.0, 1.0)
         _ShadowGradationOffset("Shadow Gradation Offset", Vector) = (0.0, 0.0, 0.0, 1.0)
-        [HDR] _ShadowColor("Shadow Color", Color) = (0.0, 0.0, 0.0, 1.0)
-        [HDR] _ShadowGradationColor("Shadow Gradation Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _ShadowColor("Shadow Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _ShadowGradationColor("Shadow Gradation Color", Color) = (0.0, 0.0, 0.0, 1.0)
 
         _GraphicEffectAngle("Graphic Effect Angle", Float) = 0
-        [HDR] _GraphicEffectColor("Graphic Effect Color", Vector) = (0.0, 0.0, 0.0, 1.0)
+        _GraphicEffectColor("Graphic Effect Color", Color) = (0.0, 0.0, 0.0, 1.0)
         _GraphicEffectOffset("Graphic Effect Offset", Vector) = (0.0, 0.0, 0.0, 1.0)
         _OutlineEffectAngle("Outline Effect Angle", Float) = 0
-        [HDR] _OutlineEffectColor("Outline Effect Color", Vector) = (0.0, 0.0, 0.0, 1.0)
+        _OutlineEffectColor("Outline Effect Color", Color) = (0.0, 0.0, 0.0, 1.0)
         _OutlineEffectOffset("Outline Effect Offset", Vector) = (0.0, 0.0, 0.0, 1.0)
 
         _GraphicEffectShinyWidth("Graphic Effect Shiny Width", Float) = 0

--- a/Runtime/Resources/Shaders/SDF-UI/Quad.shader
+++ b/Runtime/Resources/Shaders/SDF-UI/Quad.shader
@@ -40,8 +40,8 @@ Shader "Hidden/UI/SDF/Quad/Outline" {
         _OutlineGradationRange("Outline Gradation Range", Vector) = (0.0, 0.0, 0.0, 1.0)
         _OutlineGradationLayer("Outline Gradation Layer", Vector) = (0.0, 0.0, 0.0, 1.0)
         _OutlineGradationOffset("Outline Gradation Offset", Vector) = (0.0, 0.0, 0.0, 1.0)
-        [HDR] _OutlineColor("Outline Color", Color) = (0.0, 0.0, 0.0, 1.0)
-        [HDR] _OutlineGradationColor("Outline Gradation Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _OutlineColor("Outline Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _OutlineGradationColor("Outline Gradation Color", Color) = (0.0, 0.0, 0.0, 1.0)
 
         _ShadowWidth("Shadow Width", Float) = 0
         _ShadowBlur("Shadow Blur", Float) = 0
@@ -53,14 +53,14 @@ Shader "Hidden/UI/SDF/Quad/Outline" {
         _ShadowGradationRange("Shadow Gradation Range", Vector) = (0.0, 0.0, 0.0, 1.0)
         _ShadowGradationLayer("Shadow Gradation Layer", Vector) = (0.0, 0.0, 0.0, 1.0)
         _ShadowGradationOffset("Shadow Gradation Offset", Vector) = (0.0, 0.0, 0.0, 1.0)
-        [HDR] _ShadowColor("Shadow Color", Color) = (0.0, 0.0, 0.0, 1.0)
-        [HDR] _ShadowGradationColor("Shadow Gradation Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _ShadowColor("Shadow Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _ShadowGradationColor("Shadow Gradation Color", Color) = (0.0, 0.0, 0.0, 1.0)
 
         _GraphicEffectAngle("Graphic Effect Angle", Float) = 0
-        [HDR] _GraphicEffectColor("Graphic Effect Color", Vector) = (0.0, 0.0, 0.0, 1.0)
+        _GraphicEffectColor("Graphic Effect Color", Color) = (0.0, 0.0, 0.0, 1.0)
         _GraphicEffectOffset("Graphic Effect Offset", Vector) = (0.0, 0.0, 0.0, 1.0)
         _OutlineEffectAngle("Outline Effect Angle", Float) = 0
-        [HDR] _OutlineEffectColor("Outline Effect Color", Vector) = (0.0, 0.0, 0.0, 1.0)
+        _OutlineEffectColor("Outline Effect Color", Color) = (0.0, 0.0, 0.0, 1.0)
         _OutlineEffectOffset("Outline Effect Offset", Vector) = (0.0, 0.0, 0.0, 1.0)
 
         _GraphicEffectShinyWidth("Graphic Effect Shiny Width", Float) = 0

--- a/Runtime/Resources/Shaders/SDF-UI/ShaderSetup.hlsl
+++ b/Runtime/Resources/Shaders/SDF-UI/ShaderSetup.hlsl
@@ -22,6 +22,15 @@ v2f vert(appdata v) {
     o.worldPosition = v.vertex;
     o.vertex = UnityObjectToClipPos(v.vertex);
     o.uv = v.uv;
+
+    if (_UIVertexColorAlwaysGammaSpace)
+    {
+        if(!IsGammaSpace())
+        {
+            v.color.rgb = UIGammaToLinear(v.color.rgb);
+        }
+    }
+
     o.color = v.color;
 
     // This implementation is taken from Unity's build in shader UI-Default.shader.

--- a/Runtime/Resources/Shaders/SDF-UI/Spline.shader
+++ b/Runtime/Resources/Shaders/SDF-UI/Spline.shader
@@ -1,6 +1,7 @@
 Shader "Hidden/UI/SDF/Spline/Outline" {
     Properties{
         [HideInInspector] _MainTex("Texture", 2D) = "white" {}
+        [HideInInspector] _Color("Tint", Color) = (1,1,1,1)
         [HideInInspector] _StencilComp("Stencil Comparison", Float) = 8
         [HideInInspector] _Stencil("Stencil ID", Float) = 0
         [HideInInspector] _StencilOp("Stencil Operation", Float) = 0
@@ -41,8 +42,8 @@ Shader "Hidden/UI/SDF/Spline/Outline" {
         _OutlineGradationRange("Outline Gradation Range", Vector) = (0.0, 0.0, 0.0, 1.0)
         _OutlineGradationLayer("Outline Gradation Layer", Vector) = (0.0, 0.0, 0.0, 1.0)
         _OutlineGradationOffset("Outline Gradation Offset", Vector) = (0.0, 0.0, 0.0, 1.0)
-        [HDR] _OutlineColor("Outline Color", Color) = (0.0, 0.0, 0.0, 1.0)
-        [HDR] _OutlineGradationColor("Outline Gradation Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _OutlineColor("Outline Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _OutlineGradationColor("Outline Gradation Color", Color) = (0.0, 0.0, 0.0, 1.0)
 
         _ShadowWidth("Shadow Width", Float) = 0
         _ShadowBlur("Shadow Blur", Float) = 0
@@ -54,14 +55,14 @@ Shader "Hidden/UI/SDF/Spline/Outline" {
         _ShadowGradationRange("Shadow Gradation Range", Vector) = (0.0, 0.0, 0.0, 1.0)
         _ShadowGradationLayer("Shadow Gradation Layer", Vector) = (0.0, 0.0, 0.0, 1.0)
         _ShadowGradationOffset("Shadow Gradation Offset", Vector) = (0.0, 0.0, 0.0, 1.0)
-        [HDR] _ShadowColor("Shadow Color", Color) = (0.0, 0.0, 0.0, 1.0)
-        [HDR] _ShadowGradationColor("Shadow Gradation Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _ShadowColor("Shadow Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _ShadowGradationColor("Shadow Gradation Color", Color) = (0.0, 0.0, 0.0, 1.0)
 
         _GraphicEffectAngle("Graphic Effect Angle", Float) = 0
-        [HDR] _GraphicEffectColor("Graphic Effect Color", Vector) = (0.0, 0.0, 0.0, 1.0)
+        _GraphicEffectColor("Graphic Effect Color", Color) = (0.0, 0.0, 0.0, 1.0)
         _GraphicEffectOffset("Graphic Effect Offset", Vector) = (0.0, 0.0, 0.0, 1.0)
         _OutlineEffectAngle("Outline Effect Angle", Float) = 0
-        [HDR] _OutlineEffectColor("Outline Effect Color", Vector) = (0.0, 0.0, 0.0, 1.0)
+        _OutlineEffectColor("Outline Effect Color", Color) = (0.0, 0.0, 0.0, 1.0)
         _OutlineEffectOffset("Outline Effect Offset", Vector) = (0.0, 0.0, 0.0, 1.0)
 
         _GraphicEffectShinyWidth("Graphic Effect Shiny Width", Float) = 0

--- a/Runtime/Resources/Shaders/SDF-UI/Squircle.shader
+++ b/Runtime/Resources/Shaders/SDF-UI/Squircle.shader
@@ -1,6 +1,7 @@
 Shader "Hidden/UI/SDF/Squircle/Outline" {
     Properties{
         [HideInInspector] _MainTex("Texture", 2D) = "white" {}
+        [HideInInspector] _Color("Tint", Color) = (1,1,1,1)
         [HideInInspector] _StencilComp("Stencil Comparison", Float) = 8
         [HideInInspector] _Stencil("Stencil ID", Float) = 0
         [HideInInspector] _StencilOp("Stencil Operation", Float) = 0
@@ -41,8 +42,8 @@ Shader "Hidden/UI/SDF/Squircle/Outline" {
         _OutlineGradationRange("Outline Gradation Range", Vector) = (0.0, 0.0, 0.0, 1.0)
         _OutlineGradationLayer("Outline Gradation Layer", Vector) = (0.0, 0.0, 0.0, 1.0)
         _OutlineGradationOffset("Outline Gradation Offset", Vector) = (0.0, 0.0, 0.0, 1.0)
-        [HDR] _OutlineColor("Outline Color", Color) = (0.0, 0.0, 0.0, 1.0)
-        [HDR] _OutlineGradationColor("Outline Gradation Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _OutlineColor("Outline Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _OutlineGradationColor("Outline Gradation Color", Color) = (0.0, 0.0, 0.0, 1.0)
 
         _ShadowWidth("Shadow Width", Float) = 0
         _ShadowBlur("Shadow Blur", Float) = 0
@@ -54,14 +55,14 @@ Shader "Hidden/UI/SDF/Squircle/Outline" {
         _ShadowGradationRange("Shadow Gradation Range", Vector) = (0.0, 0.0, 0.0, 1.0)
         _ShadowGradationLayer("Shadow Gradation Layer", Vector) = (0.0, 0.0, 0.0, 1.0)
         _ShadowGradationOffset("Shadow Gradation Offset", Vector) = (0.0, 0.0, 0.0, 1.0)
-        [HDR] _ShadowColor("Shadow Color", Color) = (0.0, 0.0, 0.0, 1.0)
-        [HDR] _ShadowGradationColor("Shadow Gradation Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _ShadowColor("Shadow Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _ShadowGradationColor("Shadow Gradation Color", Color) = (0.0, 0.0, 0.0, 1.0)
 
         _GraphicEffectAngle("Graphic Effect Angle", Float) = 0
-        [HDR] _GraphicEffectColor("Graphic Effect Color", Vector) = (0.0, 0.0, 0.0, 1.0)
+        _GraphicEffectColor("Graphic Effect Color", Color) = (0.0, 0.0, 0.0, 1.0)
         _GraphicEffectOffset("Graphic Effect Offset", Vector) = (0.0, 0.0, 0.0, 1.0)
         _OutlineEffectAngle("Outline Effect Angle", Float) = 0
-        [HDR] _OutlineEffectColor("Outline Effect Color", Vector) = (0.0, 0.0, 0.0, 1.0)
+        _OutlineEffectColor("Outline Effect Color", Color) = (0.0, 0.0, 0.0, 1.0)
         _OutlineEffectOffset("Outline Effect Offset", Vector) = (0.0, 0.0, 0.0, 1.0)
 
         _GraphicEffectShinyWidth("Graphic Effect Shiny Width", Float) = 0

--- a/Runtime/Resources/Shaders/SDF-UI/Tex.shader
+++ b/Runtime/Resources/Shaders/SDF-UI/Tex.shader
@@ -1,6 +1,7 @@
 Shader "Hidden/UI/SDF/Tex/Outline" {
     Properties{
         [HideInInspector] _MainTex("Texture", 2D) = "white" {}
+        [HideInInspector] _Color("Tint", Color) = (1,1,1,1)
         [HideInInspector] _StencilComp("Stencil Comparison", Float) = 8
         [HideInInspector] _Stencil("Stencil ID", Float) = 0
         [HideInInspector] _StencilOp("Stencil Operation", Float) = 0
@@ -42,8 +43,8 @@ Shader "Hidden/UI/SDF/Tex/Outline" {
         _OutlineGradationRange("Outline Gradation Range", Vector) = (0.0, 0.0, 0.0, 1.0)
         _OutlineGradationLayer("Outline Gradation Layer", Vector) = (0.0, 0.0, 0.0, 1.0)
         _OutlineGradationOffset("Outline Gradation Offset", Vector) = (0.0, 0.0, 0.0, 1.0)
-        [HDR] _OutlineColor("Outline Color", Color) = (0.0, 0.0, 0.0, 1.0)
-        [HDR] _OutlineGradationColor("Outline Gradation Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _OutlineColor("Outline Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _OutlineGradationColor("Outline Gradation Color", Color) = (0.0, 0.0, 0.0, 1.0)
 
         _ShadowWidth("Shadow Width", Float) = 0
         _ShadowBlur("Shadow Blur", Float) = 0
@@ -55,14 +56,14 @@ Shader "Hidden/UI/SDF/Tex/Outline" {
         _ShadowGradationRange("Shadow Gradation Range", Vector) = (0.0, 0.0, 0.0, 1.0)
         _ShadowGradationLayer("Shadow Gradation Layer", Vector) = (0.0, 0.0, 0.0, 1.0)
         _ShadowGradationOffset("Shadow Gradation Offset", Vector) = (0.0, 0.0, 0.0, 1.0)
-        [HDR] _ShadowColor("Shadow Color", Color) = (0.0, 0.0, 0.0, 1.0)
-        [HDR] _ShadowGradationColor("Shadow Gradation Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _ShadowColor("Shadow Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _ShadowGradationColor("Shadow Gradation Color", Color) = (0.0, 0.0, 0.0, 1.0)
 
         _GraphicEffectAngle("Graphic Effect Angle", Float) = 0
-        [HDR] _GraphicEffectColor("Graphic Effect Color", Vector) = (0.0, 0.0, 0.0, 1.0)
+        _GraphicEffectColor("Graphic Effect Color", Color) = (0.0, 0.0, 0.0, 1.0)
         _GraphicEffectOffset("Graphic Effect Offset", Vector) = (0.0, 0.0, 0.0, 1.0)
         _OutlineEffectAngle("Outline Effect Angle", Float) = 0
-        [HDR] _OutlineEffectColor("Outline Effect Color", Vector) = (0.0, 0.0, 0.0, 1.0)
+        _OutlineEffectColor("Outline Effect Color", Color) = (0.0, 0.0, 0.0, 1.0)
         _OutlineEffectOffset("Outline Effect Offset", Vector) = (0.0, 0.0, 0.0, 1.0)
 
         _GraphicEffectShinyWidth("Graphic Effect Shiny Width", Float) = 0

--- a/Runtime/Resources/Shaders/SDF-UI/Triangle.shader
+++ b/Runtime/Resources/Shaders/SDF-UI/Triangle.shader
@@ -1,6 +1,7 @@
 Shader "Hidden/UI/SDF/Triangle/Outline" {
     Properties{
         [HideInInspector] _MainTex("Texture", 2D) = "white" {}
+        [HideInInspector] _Color("Tint", Color) = (1,1,1,1)
         [HideInInspector] _StencilComp("Stencil Comparison", Float) = 8
         [HideInInspector] _Stencil("Stencil ID", Float) = 0
         [HideInInspector] _StencilOp("Stencil Operation", Float) = 0
@@ -43,8 +44,8 @@ Shader "Hidden/UI/SDF/Triangle/Outline" {
         _OutlineGradationRange("Outline Gradation Range", Vector) = (0.0, 0.0, 0.0, 1.0)
         _OutlineGradationLayer("Outline Gradation Layer", Vector) = (0.0, 0.0, 0.0, 1.0)
         _OutlineGradationOffset("Outline Gradation Offset", Vector) = (0.0, 0.0, 0.0, 1.0)
-        [HDR] _OutlineColor("Outline Color", Color) = (0.0, 0.0, 0.0, 1.0)
-        [HDR] _OutlineGradationColor("Outline Gradation Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _OutlineColor("Outline Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _OutlineGradationColor("Outline Gradation Color", Color) = (0.0, 0.0, 0.0, 1.0)
 
         _ShadowWidth("Shadow Width", Float) = 0
         _ShadowBlur("Shadow Blur", Float) = 0
@@ -56,14 +57,14 @@ Shader "Hidden/UI/SDF/Triangle/Outline" {
         _ShadowGradationRange("Shadow Gradation Range", Vector) = (0.0, 0.0, 0.0, 1.0)
         _ShadowGradationLayer("Shadow Gradation Layer", Vector) = (0.0, 0.0, 0.0, 1.0)
         _ShadowGradationOffset("Shadow Gradation Offset", Vector) = (0.0, 0.0, 0.0, 1.0)
-        [HDR] _ShadowColor("Shadow Color", Color) = (0.0, 0.0, 0.0, 1.0)
-        [HDR] _ShadowGradationColor("Shadow Gradation Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _ShadowColor("Shadow Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _ShadowGradationColor("Shadow Gradation Color", Color) = (0.0, 0.0, 0.0, 1.0)
 
         _GraphicEffectAngle("Graphic Effect Angle", Float) = 0
-        [HDR] _GraphicEffectColor("Graphic Effect Color", Vector) = (0.0, 0.0, 0.0, 1.0)
+        _GraphicEffectColor("Graphic Effect Color", Color) = (0.0, 0.0, 0.0, 1.0)
         _GraphicEffectOffset("Graphic Effect Offset", Vector) = (0.0, 0.0, 0.0, 1.0)
         _OutlineEffectAngle("Outline Effect Angle", Float) = 0
-        [HDR] _OutlineEffectColor("Outline Effect Color", Vector) = (0.0, 0.0, 0.0, 1.0)
+        _OutlineEffectColor("Outline Effect Color", Color) = (0.0, 0.0, 0.0, 1.0)
         _OutlineEffectOffset("Outline Effect Offset", Vector) = (0.0, 0.0, 0.0, 1.0)
 
         _GraphicEffectShinyWidth("Graphic Effect Shiny Width", Float) = 0

--- a/Runtime/SDFUI.cs
+++ b/Runtime/SDFUI.cs
@@ -265,11 +265,11 @@ namespace TLab.UI.SDF
         [SerializeField, Min(0f)] protected float m_outlineWidth = 10;
         [SerializeField, Min(0f)] protected float m_outlineInnerSoftWidth = 0;
         [SerializeField, Range(0, 1)] protected float m_outlineInnerSoftness = 0.0f;
-        [SerializeField, ColorUsage(true, true)] protected Color m_outlineColor = Color.cyan;
+        [SerializeField] protected Color m_outlineColor = Color.cyan;
         [SerializeField] protected OutlineType m_outlineType = OutlineType.Inside;
 
         #region GRADATION
-        [SerializeField, ColorUsage(true, true)] protected Color m_outlineGradationColor = Color.cyan;
+        [SerializeField] protected Color m_outlineGradationColor = Color.cyan;
         [SerializeField, Range(0, 2)] protected float m_outlineGradationAngle = 0;
         [SerializeField, Min(0)] protected float m_outlineGradationRadius = 0.5f;
         [SerializeField, Min(0)] protected float m_outlineGradationSmooth = 0.5f;
@@ -280,7 +280,7 @@ namespace TLab.UI.SDF
 
         #region EFFECT
         [SerializeField] protected EffectType m_outlineEffectType = EffectType.None;
-        [SerializeField, ColorUsage(true, true)] protected Color m_outlineEffectColor = Color.white;
+        [SerializeField] protected Color m_outlineEffectColor = Color.white;
         [SerializeField] protected Vector2 m_outlineEffectOffset;
         [SerializeField, Range(-1, 1)] protected float m_outlineEffectAngle = 0.0f;
         [SerializeField, Range(0, 1)] protected float m_outlineEffectShinyBlur = 0.0f;
@@ -305,11 +305,11 @@ namespace TLab.UI.SDF
         [SerializeField, Range(0, 1)] protected float m_shadowSoftness = 0.0f;
         [SerializeField, Min(0f)] protected float m_shadowDilate = 0;
         [SerializeField] protected Vector2 m_shadowOffset;
-        [SerializeField, ColorUsage(true, true)] protected Color m_shadowColor = Color.black;
+        [SerializeField] protected Color m_shadowColor = Color.black;
         [SerializeField] protected EffectType m_shadowEffectType = EffectType.None;
 
         #region GRADATION
-        [SerializeField, ColorUsage(true, true)] protected Color m_shadowGradationColor = Color.black;
+        [SerializeField] protected Color m_shadowGradationColor = Color.black;
         [SerializeField, Range(0, 2)] protected float m_shadowGradationAngle = 0;
         [SerializeField, Min(0)] protected float m_shadowGradationRadius = 0.5f;
         [SerializeField, Min(0)] protected float m_shadowGradationSmooth = 0.5f;
@@ -322,14 +322,14 @@ namespace TLab.UI.SDF
 
         #region GRAPHIC
 
-        [SerializeField, ColorUsage(true)] protected Color m_fillColor = Color.white;
+        [SerializeField] protected Color m_fillColor = Color.white;
         [SerializeField] protected ActiveImageType m_activeImageType;
         [SerializeField] protected Sprite m_sprite;
         [SerializeField] protected Texture m_texture;
         [SerializeField] protected Rect m_uvRect = new Rect(0f, 0f, 1f, 1f);
 
         #region GRADATION
-        [SerializeField, ColorUsage(true)] protected Color m_gradationColor = Color.white;
+        [SerializeField] protected Color m_gradationColor = Color.white;
         [SerializeField, Range(0, 2)] protected float m_gradationAngle = 0;
         [SerializeField, Min(0)] protected float m_gradationRadius = 0.5f;
         [SerializeField, Min(0)] protected float m_gradationSmooth = 0.5f;
@@ -340,7 +340,7 @@ namespace TLab.UI.SDF
 
         #region EFFECT
         [SerializeField] protected EffectType m_graphicEffectType = EffectType.None;
-        [SerializeField, ColorUsage(true, true)] protected Color m_graphicEffectColor = Color.white;
+        [SerializeField] protected Color m_graphicEffectColor = Color.white;
         [SerializeField] protected Vector2 m_graphicEffectOffset;
         [SerializeField, Range(0, 1)] protected float m_graphicEffectAngle = 0.0f;
         [SerializeField, Range(0, 1)] protected float m_graphicEffectShinyBlur = 0.0f;

--- a/Runtime/SDFUI.cs
+++ b/Runtime/SDFUI.cs
@@ -258,6 +258,7 @@ namespace TLab.UI.SDF
         [SerializeField, Min(0f)] protected float m_onionWidth = 10;
 
         [SerializeField] protected AntialiasingType m_antialiasing = AntialiasingType.Default;
+        [SerializeField] protected bool m_useHDR = false;
 
         #region OUTLINE
 
@@ -1092,6 +1093,20 @@ namespace TLab.UI.SDF
             }
         }
 
+        public bool useHDR
+        {
+            get => m_useHDR;
+            set
+            {
+                if (m_useHDR != value)
+                {
+                    m_useHDR = value;
+
+                    SetAllDirty();
+                }
+            }
+        }
+
         public virtual Color fillColor
         {
             get => m_fillColor;
@@ -1708,6 +1723,7 @@ namespace TLab.UI.SDF
         protected override void Reset()
         {
             m_antialiasing = AntialiasingType.Default;
+            m_useHDR = SDFUISettings.Instance.UseHDR;
             m_outline = SDFUISettings.Instance.UseOutline;
             m_outlineWidth = SDFUISettings.Instance.OutlineWidth;
             m_outlineColor = SDFUISettings.Instance.OutlineColor;
@@ -1805,7 +1821,7 @@ namespace TLab.UI.SDF
             _materialRecord.SetVector(PROP_RECTSIZE, new float4(((RectTransform)transform).rect.size, 0, 0));
 
             _materialRecord.TextureUV = new float4(uvRect.x, uvRect.y, uvRect.size.x, uvRect.size.y);
-            _materialRecord.TextureColor = SDFUISettings.Instance.UseHDRColor ? m_fillColor.gamma : m_fillColor;
+            _materialRecord.TextureColor = m_useHDR ? m_fillColor.gamma : m_fillColor;
 
             var activeImageType = m_activeImageType;
             switch (activeImageType)
@@ -1859,7 +1875,7 @@ namespace TLab.UI.SDF
                         break;
                 }
 
-                _materialRecord.SetColor(PROP_GRAPHIC_GRADATION_COLOR, SDFUISettings.Instance.UseHDRColor ? gradationColor.gamma : gradationColor);
+                _materialRecord.SetColor(PROP_GRAPHIC_GRADATION_COLOR, m_useHDR ? gradationColor.gamma : gradationColor);
                 _materialRecord.SetVector(PROP_GRAPHIC_GRADATION_LAYER, gradationLayer);
 
                 _materialRecord.SetFloat(PROP_GRAPHIC_GRADATION_ANGLE, m_gradationAngle);
@@ -1893,7 +1909,7 @@ namespace TLab.UI.SDF
                 _materialRecord.SetFloat(PROP_SHADOW_WIDTH, m_shadowWidth);
                 _materialRecord.SetFloat(PROP_SHADOW_BLUR, m_shadowSoftness * (m_shadowWidth + m_shadowInnerSoftWidth));
                 _materialRecord.SetFloat(PROP_SHADOW_DILATE, m_shadowDilate);
-                _materialRecord.SetColor(PROP_SHADOW_COLOR, SDFUISettings.Instance.UseHDRColor ? m_shadowColor.gamma : m_shadowColor);
+                _materialRecord.SetColor(PROP_SHADOW_COLOR, m_useHDR ? m_shadowColor.gamma : m_shadowColor);
                 _materialRecord.SetFloat(PROP_SHADOW_GAUSSIAN, (m_shadowSoftness > 0) ? 1 : 0);
 
                 _materialRecord.SetFloat(PROP_SHADOW_GRADATION_ANGLE, m_shadowGradationAngle);
@@ -1921,7 +1937,7 @@ namespace TLab.UI.SDF
                         gradationLayer.w = 1;
                         break;
                 }
-                _materialRecord.SetColor(PROP_SHADOW_GRADATION_COLOR, SDFUISettings.Instance.UseHDRColor ? gradationColor.gamma : gradationColor);
+                _materialRecord.SetColor(PROP_SHADOW_GRADATION_COLOR, m_useHDR ? gradationColor.gamma : gradationColor);
                 _materialRecord.SetVector(PROP_SHADOW_GRADATION_LAYER, gradationLayer);
 
                 MeshUtils.ShadowSizeOffset(rectTransform.rect.size, m_shadowOffset, rectTransform.eulerAngles.z, out float4 sizeOffset);
@@ -1958,7 +1974,7 @@ namespace TLab.UI.SDF
                         _materialRecord.SetVector(PROP_GRAPHIC_EFFECT_OFFSET, m_graphicEffectOffset);
 
                         _materialRecord.SetFloat(PROP_GRAPHIC_EFFECT_ANGLE, Mathf.PI * m_graphicEffectAngle);
-                        _materialRecord.SetColor(PROP_GRAPHIC_EFFECT_COLOR, SDFUISettings.Instance.UseHDRColor ? m_graphicEffectColor.gamma : m_graphicEffectColor);
+                        _materialRecord.SetColor(PROP_GRAPHIC_EFFECT_COLOR, m_useHDR ? m_graphicEffectColor.gamma : m_graphicEffectColor);
                         break;
                     case EffectType.Pattern:
                         _materialRecord.DisableKeyword(KEYWORD_GRAPHIC_EFFECT_SHINY);
@@ -1971,7 +1987,7 @@ namespace TLab.UI.SDF
                         _materialRecord.SetVector(PROP_GRAPHIC_EFFECT_PATTERN_PARAMS, new float4(m_graphicEffectPatternParamsX, m_graphicEffectPatternParamsY, m_graphicEffectPatternParamsZ, m_graphicEffectPatternParamsW));
 
                         _materialRecord.SetFloat(PROP_GRAPHIC_EFFECT_ANGLE, Mathf.PI * m_graphicEffectAngle);
-                        _materialRecord.SetColor(PROP_GRAPHIC_EFFECT_COLOR, SDFUISettings.Instance.UseHDRColor ? m_graphicEffectColor.gamma : m_graphicEffectColor);
+                        _materialRecord.SetColor(PROP_GRAPHIC_EFFECT_COLOR, m_useHDR ? m_graphicEffectColor.gamma : m_graphicEffectColor);
                         _materialRecord.SetVector(PROP_GRAPHIC_EFFECT_OFFSET, m_graphicEffectOffset);
                         break;
                     case EffectType.Rainbow:
@@ -1989,7 +2005,7 @@ namespace TLab.UI.SDF
             if (m_outline && m_outlineWidth > 0)
             {
                 _materialRecord.SetFloat(PROP_OUTLINE_WIDTH, m_outlineWidth);
-                _materialRecord.SetColor(PROP_OUTLINE_COLOR, SDFUISettings.Instance.UseHDRColor ? m_outlineColor.gamma : m_outlineColor);
+                _materialRecord.SetColor(PROP_OUTLINE_COLOR, m_useHDR ? m_outlineColor.gamma : m_outlineColor);
                 _materialRecord.SetFloat(PROP_OUTLINE_INNER_BLUR, m_outlineInnerSoftness * m_outlineInnerSoftWidth);
                 _materialRecord.SetFloat(PROP_OUTLINE_INNER_GAUSSIAN, (m_outlineInnerSoftness > 0) && (m_outlineInnerSoftWidth > 0) ? 1 : 0);
 
@@ -2035,7 +2051,7 @@ namespace TLab.UI.SDF
                         gradationLayer.w = 1;
                         break;
                 }
-                _materialRecord.SetColor(PROP_OUTLINE_GRADATION_COLOR, SDFUISettings.Instance.UseHDRColor ? gradationColor.gamma : gradationColor);
+                _materialRecord.SetColor(PROP_OUTLINE_GRADATION_COLOR, m_useHDR ? gradationColor.gamma : gradationColor);
                 _materialRecord.SetVector(PROP_OUTLINE_GRADATION_LAYER, gradationLayer);
 
                 var patternType = m_outlineEffectType;
@@ -2052,7 +2068,7 @@ namespace TLab.UI.SDF
                         _materialRecord.SetFloat(PROP_OUTLINE_EFFECT_SHINY_BLUR, hminSize * m_outlineEffectShinyBlur);
 
                         _materialRecord.SetFloat(PROP_OUTLINE_EFFECT_ANGLE, Mathf.PI * m_outlineEffectAngle);
-                        _materialRecord.SetColor(PROP_OUTLINE_EFFECT_COLOR, SDFUISettings.Instance.UseHDRColor ? m_outlineEffectColor.gamma : m_outlineEffectColor);
+                        _materialRecord.SetColor(PROP_OUTLINE_EFFECT_COLOR, m_useHDR ? m_outlineEffectColor.gamma : m_outlineEffectColor);
                         _materialRecord.SetVector(PROP_OUTLINE_EFFECT_OFFSET, m_outlineEffectOffset);
 
                         // Set outline rainbow properties
@@ -2070,7 +2086,7 @@ namespace TLab.UI.SDF
                         _materialRecord.SetVector(PROP_OUTLINE_EFFECT_PATTERN_PARAMS, new float4(m_outlineEffectPatternParamsX, m_outlineEffectPatternParamsY, m_outlineEffectPatternParamsZ, m_outlineEffectPatternParamsW));
 
                         _materialRecord.SetFloat(PROP_OUTLINE_EFFECT_ANGLE, Mathf.PI * m_outlineEffectAngle);
-                        _materialRecord.SetColor(PROP_OUTLINE_EFFECT_COLOR, SDFUISettings.Instance.UseHDRColor ? m_outlineEffectColor.gamma : m_outlineEffectColor);
+                        _materialRecord.SetColor(PROP_OUTLINE_EFFECT_COLOR, m_useHDR ? m_outlineEffectColor.gamma : m_outlineEffectColor);
                         _materialRecord.SetVector(PROP_OUTLINE_EFFECT_OFFSET, m_outlineEffectOffset);
                         break;
                     case EffectType.Rainbow:
@@ -2087,8 +2103,8 @@ namespace TLab.UI.SDF
             else
             {
                 _materialRecord.SetFloat(PROP_OUTLINE_WIDTH, 0);
-                _materialRecord.SetColor(PROP_OUTLINE_COLOR, SDFUISettings.Instance.UseHDRColor ? m_fillColor.gamma : m_fillColor);
-                _materialRecord.SetColor(PROP_OUTLINE_GRADATION_COLOR, SDFUISettings.Instance.UseHDRColor ? m_fillColor.gamma : m_fillColor);
+                _materialRecord.SetColor(PROP_OUTLINE_COLOR, m_useHDR ? m_fillColor.gamma : m_fillColor);
+                _materialRecord.SetColor(PROP_OUTLINE_GRADATION_COLOR, m_useHDR ? m_fillColor.gamma : m_fillColor);
 
                 _materialRecord.SetFloat(PROP_SHADOW_BORDER, (m_shadowWidth - m_shadowDilate));
                 _materialRecord.SetFloat(PROP_OUTLINE_BORDER, 0);

--- a/Runtime/SDFUI.cs
+++ b/Runtime/SDFUI.cs
@@ -1805,7 +1805,7 @@ namespace TLab.UI.SDF
             _materialRecord.SetVector(PROP_RECTSIZE, new float4(((RectTransform)transform).rect.size, 0, 0));
 
             _materialRecord.TextureUV = new float4(uvRect.x, uvRect.y, uvRect.size.x, uvRect.size.y);
-            _materialRecord.TextureColor = m_fillColor;
+            _materialRecord.TextureColor = SDFUISettings.Instance.UseHDRColor ? m_fillColor.gamma : m_fillColor;
 
             var activeImageType = m_activeImageType;
             switch (activeImageType)
@@ -1859,7 +1859,7 @@ namespace TLab.UI.SDF
                         break;
                 }
 
-                _materialRecord.SetColor(PROP_GRAPHIC_GRADATION_COLOR, gradationColor);
+                _materialRecord.SetColor(PROP_GRAPHIC_GRADATION_COLOR, SDFUISettings.Instance.UseHDRColor ? gradationColor.gamma : gradationColor);
                 _materialRecord.SetVector(PROP_GRAPHIC_GRADATION_LAYER, gradationLayer);
 
                 _materialRecord.SetFloat(PROP_GRAPHIC_GRADATION_ANGLE, m_gradationAngle);
@@ -1893,7 +1893,7 @@ namespace TLab.UI.SDF
                 _materialRecord.SetFloat(PROP_SHADOW_WIDTH, m_shadowWidth);
                 _materialRecord.SetFloat(PROP_SHADOW_BLUR, m_shadowSoftness * (m_shadowWidth + m_shadowInnerSoftWidth));
                 _materialRecord.SetFloat(PROP_SHADOW_DILATE, m_shadowDilate);
-                _materialRecord.SetColor(PROP_SHADOW_COLOR, m_shadowColor);
+                _materialRecord.SetColor(PROP_SHADOW_COLOR, SDFUISettings.Instance.UseHDRColor ? m_shadowColor.gamma : m_shadowColor);
                 _materialRecord.SetFloat(PROP_SHADOW_GAUSSIAN, (m_shadowSoftness > 0) ? 1 : 0);
 
                 _materialRecord.SetFloat(PROP_SHADOW_GRADATION_ANGLE, m_shadowGradationAngle);
@@ -1921,7 +1921,7 @@ namespace TLab.UI.SDF
                         gradationLayer.w = 1;
                         break;
                 }
-                _materialRecord.SetColor(PROP_SHADOW_GRADATION_COLOR, gradationColor);
+                _materialRecord.SetColor(PROP_SHADOW_GRADATION_COLOR, SDFUISettings.Instance.UseHDRColor ? gradationColor.gamma : gradationColor);
                 _materialRecord.SetVector(PROP_SHADOW_GRADATION_LAYER, gradationLayer);
 
                 MeshUtils.ShadowSizeOffset(rectTransform.rect.size, m_shadowOffset, rectTransform.eulerAngles.z, out float4 sizeOffset);
@@ -1958,7 +1958,7 @@ namespace TLab.UI.SDF
                         _materialRecord.SetVector(PROP_GRAPHIC_EFFECT_OFFSET, m_graphicEffectOffset);
 
                         _materialRecord.SetFloat(PROP_GRAPHIC_EFFECT_ANGLE, Mathf.PI * m_graphicEffectAngle);
-                        _materialRecord.SetColor(PROP_GRAPHIC_EFFECT_COLOR, m_graphicEffectColor);
+                        _materialRecord.SetColor(PROP_GRAPHIC_EFFECT_COLOR, SDFUISettings.Instance.UseHDRColor ? m_graphicEffectColor.gamma : m_graphicEffectColor);
                         break;
                     case EffectType.Pattern:
                         _materialRecord.DisableKeyword(KEYWORD_GRAPHIC_EFFECT_SHINY);
@@ -1971,7 +1971,7 @@ namespace TLab.UI.SDF
                         _materialRecord.SetVector(PROP_GRAPHIC_EFFECT_PATTERN_PARAMS, new float4(m_graphicEffectPatternParamsX, m_graphicEffectPatternParamsY, m_graphicEffectPatternParamsZ, m_graphicEffectPatternParamsW));
 
                         _materialRecord.SetFloat(PROP_GRAPHIC_EFFECT_ANGLE, Mathf.PI * m_graphicEffectAngle);
-                        _materialRecord.SetColor(PROP_GRAPHIC_EFFECT_COLOR, m_graphicEffectColor);
+                        _materialRecord.SetColor(PROP_GRAPHIC_EFFECT_COLOR, SDFUISettings.Instance.UseHDRColor ? m_graphicEffectColor.gamma : m_graphicEffectColor);
                         _materialRecord.SetVector(PROP_GRAPHIC_EFFECT_OFFSET, m_graphicEffectOffset);
                         break;
                     case EffectType.Rainbow:
@@ -1989,7 +1989,7 @@ namespace TLab.UI.SDF
             if (m_outline && m_outlineWidth > 0)
             {
                 _materialRecord.SetFloat(PROP_OUTLINE_WIDTH, m_outlineWidth);
-                _materialRecord.SetColor(PROP_OUTLINE_COLOR, m_outlineColor);
+                _materialRecord.SetColor(PROP_OUTLINE_COLOR, SDFUISettings.Instance.UseHDRColor ? m_outlineColor.gamma : m_outlineColor);
                 _materialRecord.SetFloat(PROP_OUTLINE_INNER_BLUR, m_outlineInnerSoftness * m_outlineInnerSoftWidth);
                 _materialRecord.SetFloat(PROP_OUTLINE_INNER_GAUSSIAN, (m_outlineInnerSoftness > 0) && (m_outlineInnerSoftWidth > 0) ? 1 : 0);
 
@@ -2035,7 +2035,7 @@ namespace TLab.UI.SDF
                         gradationLayer.w = 1;
                         break;
                 }
-                _materialRecord.SetColor(PROP_OUTLINE_GRADATION_COLOR, gradationColor);
+                _materialRecord.SetColor(PROP_OUTLINE_GRADATION_COLOR, SDFUISettings.Instance.UseHDRColor ? gradationColor.gamma : gradationColor);
                 _materialRecord.SetVector(PROP_OUTLINE_GRADATION_LAYER, gradationLayer);
 
                 var patternType = m_outlineEffectType;
@@ -2052,7 +2052,7 @@ namespace TLab.UI.SDF
                         _materialRecord.SetFloat(PROP_OUTLINE_EFFECT_SHINY_BLUR, hminSize * m_outlineEffectShinyBlur);
 
                         _materialRecord.SetFloat(PROP_OUTLINE_EFFECT_ANGLE, Mathf.PI * m_outlineEffectAngle);
-                        _materialRecord.SetColor(PROP_OUTLINE_EFFECT_COLOR, m_outlineEffectColor);
+                        _materialRecord.SetColor(PROP_OUTLINE_EFFECT_COLOR, SDFUISettings.Instance.UseHDRColor ? m_outlineEffectColor.gamma : m_outlineEffectColor);
                         _materialRecord.SetVector(PROP_OUTLINE_EFFECT_OFFSET, m_outlineEffectOffset);
 
                         // Set outline rainbow properties
@@ -2070,7 +2070,7 @@ namespace TLab.UI.SDF
                         _materialRecord.SetVector(PROP_OUTLINE_EFFECT_PATTERN_PARAMS, new float4(m_outlineEffectPatternParamsX, m_outlineEffectPatternParamsY, m_outlineEffectPatternParamsZ, m_outlineEffectPatternParamsW));
 
                         _materialRecord.SetFloat(PROP_OUTLINE_EFFECT_ANGLE, Mathf.PI * m_outlineEffectAngle);
-                        _materialRecord.SetColor(PROP_OUTLINE_EFFECT_COLOR, m_outlineEffectColor);
+                        _materialRecord.SetColor(PROP_OUTLINE_EFFECT_COLOR, SDFUISettings.Instance.UseHDRColor ? m_outlineEffectColor.gamma : m_outlineEffectColor);
                         _materialRecord.SetVector(PROP_OUTLINE_EFFECT_OFFSET, m_outlineEffectOffset);
                         break;
                     case EffectType.Rainbow:
@@ -2087,8 +2087,8 @@ namespace TLab.UI.SDF
             else
             {
                 _materialRecord.SetFloat(PROP_OUTLINE_WIDTH, 0);
-                _materialRecord.SetColor(PROP_OUTLINE_COLOR, m_fillColor);
-                _materialRecord.SetColor(PROP_OUTLINE_GRADATION_COLOR, m_fillColor);
+                _materialRecord.SetColor(PROP_OUTLINE_COLOR, SDFUISettings.Instance.UseHDRColor ? m_fillColor.gamma : m_fillColor);
+                _materialRecord.SetColor(PROP_OUTLINE_GRADATION_COLOR, SDFUISettings.Instance.UseHDRColor ? m_fillColor.gamma : m_fillColor);
 
                 _materialRecord.SetFloat(PROP_SHADOW_BORDER, (m_shadowWidth - m_shadowDilate));
                 _materialRecord.SetFloat(PROP_OUTLINE_BORDER, 0);

--- a/Runtime/SDFUISettings.cs
+++ b/Runtime/SDFUISettings.cs
@@ -18,7 +18,7 @@ namespace TLab.UI.SDF
 		[SerializeField] private bool _useShadow;
 		[SerializeField] private Color _shadowColor = new(0, 0, 0, 0.25f);
 		[SerializeField] private Vector2 _shadowOffset = new(0, 4);
-		[SerializeField] private bool _useHDRColor;
+		[SerializeField] private bool _useHDR;
 
 		public AntialiasingType DefaultAA => _defaultAA;
 		public bool UseOutline => _useOutline;
@@ -29,10 +29,10 @@ namespace TLab.UI.SDF
 		public bool UseShadow => _useShadow;
 		public Color ShadowColor => _shadowColor;
 		public Vector2 ShadowOffset => _shadowOffset;
-		public bool UseHDRColor => _useHDRColor;
+		public bool UseHDR => _useHDR;
 
 #if UNITY_EDITOR
-		public static event Action SettingsChanged;
+		public static event Action AASettingsChanged;
 #endif
 
 		public static SDFUISettings Instance
@@ -60,7 +60,6 @@ namespace TLab.UI.SDF
 		}
 
 		private AntialiasingType oldAA = AntialiasingType.Default;
-		private bool oldUseHDRColor = false;
 
 		private static SDFUISettings instance;
 
@@ -73,13 +72,8 @@ namespace TLab.UI.SDF
 				oldAA = _defaultAA;
 			if (_defaultAA != oldAA)
 			{
-				SettingsChanged?.Invoke();
+				AASettingsChanged?.Invoke();
 				oldAA = _defaultAA;
-			}
-			if (oldUseHDRColor != _useHDRColor)
-			{
-				SettingsChanged?.Invoke();
-				oldUseHDRColor = _useHDRColor;
 			}
 		}
 

--- a/Runtime/SDFUISettings.cs
+++ b/Runtime/SDFUISettings.cs
@@ -18,6 +18,7 @@ namespace TLab.UI.SDF
 		[SerializeField] private bool _useShadow;
 		[SerializeField] private Color _shadowColor = new(0, 0, 0, 0.25f);
 		[SerializeField] private Vector2 _shadowOffset = new(0, 4);
+		[SerializeField] private bool _useHDRColor;
 
 		public AntialiasingType DefaultAA => _defaultAA;
 		public bool UseOutline => _useOutline;
@@ -28,9 +29,10 @@ namespace TLab.UI.SDF
 		public bool UseShadow => _useShadow;
 		public Color ShadowColor => _shadowColor;
 		public Vector2 ShadowOffset => _shadowOffset;
+		public bool UseHDRColor => _useHDRColor;
 
 #if UNITY_EDITOR
-		public static event Action AASettingsChanged;
+		public static event Action SettingsChanged;
 #endif
 
 		public static SDFUISettings Instance
@@ -58,6 +60,7 @@ namespace TLab.UI.SDF
 		}
 
 		private AntialiasingType oldAA = AntialiasingType.Default;
+		private bool oldUseHDRColor = false;
 
 		private static SDFUISettings instance;
 
@@ -70,8 +73,13 @@ namespace TLab.UI.SDF
 				oldAA = _defaultAA;
 			if (_defaultAA != oldAA)
 			{
-				AASettingsChanged?.Invoke();
+				SettingsChanged?.Invoke();
 				oldAA = _defaultAA;
+			}
+			if (oldUseHDRColor != _useHDRColor)
+			{
+				SettingsChanged?.Invoke();
+				oldUseHDRColor = _useHDRColor;
 			}
 		}
 


### PR DESCRIPTION
related issue #31 

- Whether to set each component individually
- Whether to perform color space conversion in components or shaders

Currently, it is a single setting for the entire project, and the color converted using Color.gamma in the component is set to the material.