### PR TITLE
Fixes the rainbow effect appearing differently depending on the color space.

### DIFF
--- a/Runtime/Resources/Shaders/SDF-UI/ApproxSquircle.shader
+++ b/Runtime/Resources/Shaders/SDF-UI/ApproxSquircle.shader
@@ -18,8 +18,6 @@ Shader "Hidden/UI/SDF/ApproxSquircle/Outline" {
         [HideInInspector] _OutlineBorder("Outline Border", Float) = 0
         [HideInInspector] _ShadowBorder("Shadow Border", Float) = 0
 
-        [HideInInspector] _Gamma("Gamma", Float) = 0.455 // 1.0 / 2.2
-
         _Roundness("Roundness", Float) = 0
         _Iteration("Iteration", Float) = 0
         [HideInInspector] _MinSize("MinSize", Float) = 0
@@ -105,9 +103,10 @@ Shader "Hidden/UI/SDF/ApproxSquircle/Outline" {
 #define SDF_UI_APPROX_SQUIRCLE
             #include "UnityCG.cginc"
             #include "UnityUI.cginc"
+            #include "SDFUtils.cginc"
 
             #include "ApproxSquircle-Properties.hlsl"
-            #include "SDFUtils.cginc"
+
             #include "ShaderSetup.hlsl"
 
             #pragma vertex vert

--- a/Runtime/Resources/Shaders/SDF-UI/Arc.shader
+++ b/Runtime/Resources/Shaders/SDF-UI/Arc.shader
@@ -18,8 +18,6 @@ Shader "Hidden/UI/SDF/Arc/Outline" {
         [HideInInspector] _OutlineBorder("Outline Border", Float) = 0
         [HideInInspector] _ShadowBorder("Shadow Border", Float) = 0
 
-        [HideInInspector] _Gamma("Gamma", Float) = 0.455 // 1.0 / 2.2
-
         _Radius("Radius", Float) = 0
         _Width("Width", Float) = 0
         _ActualWidth("Actual Width", Float) = 0
@@ -108,9 +106,10 @@ Shader "Hidden/UI/SDF/Arc/Outline" {
 #define SDF_UI_ARC
             #include "UnityCG.cginc"
             #include "UnityUI.cginc"
+            #include "SDFUtils.cginc"
 
             #include "Arc-Properties.hlsl"
-            #include "SDFUtils.cginc"
+
             #include "ShaderSetup.hlsl"
 
             #pragma vertex vert

--- a/Runtime/Resources/Shaders/SDF-UI/Circle.shader
+++ b/Runtime/Resources/Shaders/SDF-UI/Circle.shader
@@ -18,8 +18,6 @@ Shader "Hidden/UI/SDF/Circle/Outline" {
         [HideInInspector] _OutlineBorder("Outline Border", Float) = 0
         [HideInInspector] _ShadowBorder("Shadow Border", Float) = 0
 
-        [HideInInspector] _Gamma("Gamma", Float) = 0.455 // 1.0 / 2.2
-
         _Radius("Radius", Float) = 0
 
         _Onion("Onion", Float) = 0
@@ -103,9 +101,10 @@ Shader "Hidden/UI/SDF/Circle/Outline" {
 #define SDF_UI_CIRCLE
             #include "UnityCG.cginc"
             #include "UnityUI.cginc"
+            #include "SDFUtils.cginc"
 
             #include "Circle-Properties.hlsl"
-            #include "SDFUtils.cginc"
+
             #include "ShaderSetup.hlsl"
 
             #pragma vertex vert

--- a/Runtime/Resources/Shaders/SDF-UI/Common-Properties.hlsl
+++ b/Runtime/Resources/Shaders/SDF-UI/Common-Properties.hlsl
@@ -4,8 +4,6 @@
 
 float4 _RectSize;
 
-float _Gamma;
-
 float _Padding;
 float _EulerZ;
 float4 _OuterUV;

--- a/Runtime/Resources/Shaders/SDF-UI/CutDisk.shader
+++ b/Runtime/Resources/Shaders/SDF-UI/CutDisk.shader
@@ -18,8 +18,6 @@ Shader "Hidden/UI/SDF/CutDisk/Outline" {
         [HideInInspector] _OutlineBorder("Outline Border", Float) = 0
         [HideInInspector] _ShadowBorder("Shadow Border", Float) = 0
 
-        [HideInInspector] _Gamma("Gamma", Float) = 0.455 // 1.0 / 2.2
-
         _Radius("Radius", Float) = 0
         _Height("Height", Float) = 0
 
@@ -104,9 +102,10 @@ Shader "Hidden/UI/SDF/CutDisk/Outline" {
 #define SDF_UI_CUT_DISK
             #include "UnityCG.cginc"
             #include "UnityUI.cginc"
+            #include "SDFUtils.cginc"
 
             #include "CutDisk-Properties.hlsl"
-            #include "SDFUtils.cginc"
+
             #include "ShaderSetup.hlsl"
 
             #pragma vertex vert

--- a/Runtime/Resources/Shaders/SDF-UI/Parallelogram.shader
+++ b/Runtime/Resources/Shaders/SDF-UI/Parallelogram.shader
@@ -18,8 +18,6 @@ Shader "Hidden/UI/SDF/Parallelogram/Outline" {
         [HideInInspector] _OutlineBorder("Outline Border", Float) = 0
         [HideInInspector] _ShadowBorder("Shadow Border", Float) = 0
 
-        [HideInInspector] _Gamma("Gamma", Float) = 0.455 // 1.0 / 2.2
-
         _Slide("Slide", Float) = 0
         _Roundness("Roundness", Float) = 0
 
@@ -104,9 +102,10 @@ Shader "Hidden/UI/SDF/Parallelogram/Outline" {
 #define SDF_UI_PARALLELOGRAM
             #include "UnityCG.cginc"
             #include "UnityUI.cginc"
+            #include "SDFUtils.cginc"
 
             #include "Parallelogram-Properties.hlsl"
-            #include "SDFUtils.cginc"
+
             #include "ShaderSetup.hlsl"
 
             #pragma vertex vert

--- a/Runtime/Resources/Shaders/SDF-UI/Pie.shader
+++ b/Runtime/Resources/Shaders/SDF-UI/Pie.shader
@@ -18,8 +18,6 @@ Shader "Hidden/UI/SDF/Pie/Outline" {
         [HideInInspector] _OutlineBorder("Outline Border", Float) = 0
         [HideInInspector] _ShadowBorder("Shadow Border", Float) = 0
 
-        [HideInInspector] _Gamma("Gamma", Float) = 0.455 // 1.0 / 2.2
-
         _Radius("Radius", Float) = 0
         _Theta("Theta", Float) = 0
         _Roundness("Roundness", Float) = 0
@@ -105,9 +103,10 @@ Shader "Hidden/UI/SDF/Pie/Outline" {
 #define SDF_UI_PIE
             #include "UnityCG.cginc"
             #include "UnityUI.cginc"
+            #include "SDFUtils.cginc"
 
             #include "Pie-Properties.hlsl"
-            #include "SDFUtils.cginc"
+
             #include "ShaderSetup.hlsl"
 
             #pragma vertex vert

--- a/Runtime/Resources/Shaders/SDF-UI/Quad.shader
+++ b/Runtime/Resources/Shaders/SDF-UI/Quad.shader
@@ -19,8 +19,6 @@ Shader "Hidden/UI/SDF/Quad/Outline" {
         [HideInInspector] _OutlineBorder("Outline Border", Float) = 0
         [HideInInspector] _ShadowBorder("Shadow Border", Float) = 0
 
-        [HideInInspector] _Gamma("Gamma", Float) = 0.455 // 1.0 / 2.2
-
         _Radius("Radius", Vector) = (0, 0, 0, 0)
 
         _Onion("Onion", Float) = 0
@@ -104,9 +102,10 @@ Shader "Hidden/UI/SDF/Quad/Outline" {
 #define SDF_UI_QUAD
             #include "UnityCG.cginc"
             #include "UnityUI.cginc"
+            #include "SDFUtils.cginc"
 
             #include "Quad-Properties.hlsl"
-            #include "SDFUtils.cginc"
+
             #include "ShaderSetup.hlsl"
 
             #pragma vertex vert

--- a/Runtime/Resources/Shaders/SDF-UI/SDFUtils.cginc
+++ b/Runtime/Resources/Shaders/SDF-UI/SDFUtils.cginc
@@ -161,7 +161,7 @@ inline float4 linearGradation(float2 p, float angle, float rectAngle, float smoo
 inline float3 hsv2rgb(float3 hsv) {
     float4 K = float4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
     float3 p = abs(frac(hsv.xxx + K.xyz) * 6.0 - K.www);
-    return pow(hsv.z * lerp(K.xxx, saturate(p - K.xxx), hsv.y), _Gamma);
+    return hsv.z * lerp(K.xxx, saturate(p - K.xxx), hsv.y);
 }
 
 /**

--- a/Runtime/Resources/Shaders/SDF-UI/SDFUtils.cginc
+++ b/Runtime/Resources/Shaders/SDF-UI/SDFUtils.cginc
@@ -161,7 +161,12 @@ inline float4 linearGradation(float2 p, float angle, float rectAngle, float smoo
 inline float3 hsv2rgb(float3 hsv) {
     float4 K = float4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
     float3 p = abs(frac(hsv.xxx + K.xyz) * 6.0 - K.www);
-    return hsv.z * lerp(K.xxx, saturate(p - K.xxx), hsv.y);
+    float3 rgb = hsv.z * lerp(K.xxx, saturate(p - K.xxx), hsv.y);
+    if (!IsGammaSpace())
+    {
+        rgb = UIGammaToLinear(rgb);
+    }
+    return rgb;
 }
 
 /**

--- a/Runtime/Resources/Shaders/SDF-UI/Spline.shader
+++ b/Runtime/Resources/Shaders/SDF-UI/Spline.shader
@@ -18,8 +18,6 @@ Shader "Hidden/UI/SDF/Spline/Outline" {
         [HideInInspector] _OutlineBorder("Outline Border", Float) = 0
         [HideInInspector] _ShadowBorder("Shadow Border", Float) = 0
 
-        [HideInInspector] _Gamma("Gamma", Float) = 0.455 // 1.0 / 2.2
-
         [HideInInspector] _Num("Num", Int) = 0
 
         _Width("Width", Float) = 0
@@ -105,9 +103,9 @@ Shader "Hidden/UI/SDF/Spline/Outline" {
 #define SDF_UI_SPLINE
             #include "UnityCG.cginc"
             #include "UnityUI.cginc"
+            #include "SDFUtils.cginc"
 
             #include "Spline-ShaderSetup.hlsl"
-            #include "SDFUtils.cginc"
             #include "ShaderSetup.hlsl"
 
             #pragma vertex vert

--- a/Runtime/Resources/Shaders/SDF-UI/Squircle.shader
+++ b/Runtime/Resources/Shaders/SDF-UI/Squircle.shader
@@ -18,8 +18,6 @@ Shader "Hidden/UI/SDF/Squircle/Outline" {
         [HideInInspector] _OutlineBorder("Outline Border", Float) = 0
         [HideInInspector] _ShadowBorder("Shadow Border", Float) = 0
 
-        [HideInInspector] _Gamma("Gamma", Float) = 0.455 // 1.0 / 2.2
-
         _Roundness("Roundness", Float) = 0
         _Iteration("Iteration", Float) = 0
         [HideInInspector] _MinSize("MinSize", Float) = 0
@@ -105,9 +103,10 @@ Shader "Hidden/UI/SDF/Squircle/Outline" {
 #define SDF_UI_SQUIRCLE
             #include "UnityCG.cginc"
             #include "UnityUI.cginc"
+            #include "SDFUtils.cginc"
 
             #include "Squircle-Properties.hlsl"
-            #include "SDFUtils.cginc"
+
             #include "ShaderSetup.hlsl"
 
             #pragma vertex vert

--- a/Runtime/Resources/Shaders/SDF-UI/Tex.shader
+++ b/Runtime/Resources/Shaders/SDF-UI/Tex.shader
@@ -19,8 +19,6 @@ Shader "Hidden/UI/SDF/Tex/Outline" {
         [HideInInspector] _OutlineBorder("Outline Border", Float) = 0
         [HideInInspector] _ShadowBorder("Shadow Border", Float) = 0
 
-        [HideInInspector] _Gamma("Gamma", Float) = 0.455 // 1.0 / 2.2
-
         _SDFTex("SDFTex", 2D) = "white" {}
 
         _Radius("Radius", Float) = 0
@@ -106,9 +104,10 @@ Shader "Hidden/UI/SDF/Tex/Outline" {
 #define SDF_UI_TEX
             #include "UnityCG.cginc"
             #include "UnityUI.cginc"
+            #include "SDFUtils.cginc"
 
             #include "Tex-Properties.hlsl"
-            #include "SDFUtils.cginc"
+
             #include "ShaderSetup.hlsl"
 
             #pragma vertex vert

--- a/Runtime/Resources/Shaders/SDF-UI/Triangle.shader
+++ b/Runtime/Resources/Shaders/SDF-UI/Triangle.shader
@@ -18,8 +18,6 @@ Shader "Hidden/UI/SDF/Triangle/Outline" {
         [HideInInspector] _OutlineBorder("Outline Border", Float) = 0
         [HideInInspector] _ShadowBorder("Shadow Border", Float) = 0
 
-        [HideInInspector] _Gamma("Gamma", Float) = 0.455 // 1.0 / 2.2
-
         __Roundness("Roundness", Float) = 0
 
         _Corner0("Corner 0", Vector) = (0, 0, 0, 0)
@@ -107,9 +105,9 @@ Shader "Hidden/UI/SDF/Triangle/Outline" {
 #define SDF_UI_TRIANGLE
             #include "UnityCG.cginc"
             #include "UnityUI.cginc"
+            #include "SDFUtils.cginc"
 
             #include "Triangle-Properties.hlsl"
-            #include "SDFUtils.cginc"
             #include "ShaderSetup.hlsl"
 
             #pragma vertex vert


### PR DESCRIPTION
Aligned the results of `Linear` with the results of `Gamma`.
Expected to be merged before #33.

Related issue: #31